### PR TITLE
Ares I rebalance

### DIFF
--- a/reDIRECT_0.9.10/GameData/reDIRECT/Phase3/Parts/Ares_I/DIRECT_SLS_ICPS.cfg
+++ b/reDIRECT_0.9.10/GameData/reDIRECT/Phase3/Parts/Ares_I/DIRECT_SLS_ICPS.cfg
@@ -13,9 +13,9 @@ PART
 	subcategory = 0
 	title = Dual-Bulkhead Cryogenic Propellant Assembly
 	manufacturer = Olympus Spaceflight Emporium
-	description = A cryogenic upper stage with multiple attachment configurations. 
+	description = A cryogenic upper stage with multiple attachment configurations.
 	attachRules = 1,1,1,1,0
-	mass = 3.5
+	mass = 1.1
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.3
@@ -41,7 +41,7 @@ PART
 	}
 	node_stack_bottom = 0.0, -0.748, 0.0, 0.0, -1.0, 0.0, 2
 
-	tags = orange, direct, SLS, stack, cryogenic, upper stage, decoupler
+	tags = orange, direct, SLS, stack, cryogenic, upper stage, decoupler, ICPS, interim, delta
 
 	MODEL
 	{
@@ -62,13 +62,13 @@ PART
 	RESOURCE
 	{
 		name = LqdHydrogen
-		amount = 14542.45
-		maxAmount = 14542.45
+		amount = 16500
+		maxAmount = 16500
 	}
 	RESOURCE
 	{
 		name = Oxidizer
-		amount = 969.53
-		maxAmount = 969.53
+		amount = 1100
+		maxAmount = 1100
 	}
 }

--- a/reDIRECT_0.9.10/GameData/reDIRECT/Phase3/Parts/Ares_I/DIRECT_SLS_ICPS.cfg
+++ b/reDIRECT_0.9.10/GameData/reDIRECT/Phase3/Parts/Ares_I/DIRECT_SLS_ICPS.cfg
@@ -41,7 +41,7 @@ PART
 	}
 	node_stack_bottom = 0.0, -0.748, 0.0, 0.0, -1.0, 0.0, 2
 
-	tags = orange, direct, SLS, stack, cryogenic, upper stage, decoupler, ICPS, interim, delta
+	tags = orange, direct, SLS, stack, cryogenic, upper stage, decoupler, ICPS, interim, delta, DCSS
 
 	MODEL
 	{

--- a/reDIRECT_0.9.10/GameData/reDIRECT/Phase3/Parts/Ares_I/DIRECT_ares1_interTank.cfg
+++ b/reDIRECT_0.9.10/GameData/reDIRECT/Phase3/Parts/Ares_I/DIRECT_ares1_interTank.cfg
@@ -13,9 +13,9 @@ PART
 	subcategory = 0
 	title = Olympus S2-3-2 3.125m Cryogenic Tank
 	manufacturer = Olympus Spaceflight Emporium
-	description = A moderately large cryogenic tank. 
+	description = A moderately large cryogenic tank.
 	attachRules = 1,1,1,1,0
-	mass = 2.63
+	mass = 1.02
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.3
@@ -51,13 +51,13 @@ PART
 	RESOURCE
 	{
 		name = LqdHydrogen
-		amount = 16421.444
-		maxAmount = 16421.444
+		amount = 15375
+		maxAmount = 15375
 	}
 	RESOURCE
 	{
 		name = Oxidizer
-		amount = 1094.808
-		maxAmount = 1094.808
+		amount = 1025
+		maxAmount = 1025
 	}
 }

--- a/reDIRECT_0.9.10/GameData/reDIRECT/Phase3/Parts/Ares_I/DIRECT_ares1_mainTank.cfg
+++ b/reDIRECT_0.9.10/GameData/reDIRECT/Phase3/Parts/Ares_I/DIRECT_ares1_mainTank.cfg
@@ -13,9 +13,9 @@ PART
 	subcategory = 0
 	title = Olympus S2-3-1 3.125m Cryogenic Tank
 	manufacturer = Olympus Spaceflight Emporium
-	description = An incredibly large cryogenic tank. 
+	description = An incredibly large cryogenic tank.
 	attachRules = 1,1,1,1,0
-	mass = 5.76
+	mass = 2.325 //5.76
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.3
@@ -51,13 +51,13 @@ PART
 	RESOURCE
 	{
 		name = LqdHydrogen
-		amount = 35916.764
-		maxAmount = 35916.764
+		amount = 34875
+		maxAmount = 34875 
 	}
 	RESOURCE
 	{
 		name = Oxidizer
-		amount = 2394.548
-		maxAmount = 2394.548
+		amount = 2325
+		maxAmount = 2325
 	}
 }

--- a/reDIRECT_0.9.10/GameData/reDIRECT/Phase3/Parts/Engines/DIRECT_K2X.cfg
+++ b/reDIRECT_0.9.10/GameData/reDIRECT/Phase3/Parts/Engines/DIRECT_K2X.cfg
@@ -11,9 +11,9 @@ PART
 	subcategory = 0
 	title = K-2X "Jackdaw" Cryogenic Rocket Engine
 	manufacturer = Olympus Spaceflight Emporium
-	description = Revived and upgraded from lost Design Bureau engines, the Jackdaw is an accomplished 1.875m cryogenic sustainer engines with enough thrust for sea level use as well. 
+	description = Revived and upgraded from lost Design Bureau engines, the Jackdaw is an accomplished 1.875m cryogenic sustainer engines with enough thrust for sea level use as well.
 	attachRules = 1,0,1,0,0
-	mass = 7.7
+	mass = 2 // 7.7
 	heatConductivity = 0.06 // half default
 	skinInternalConductionMult = 4.0
 	emissiveConstant = 0.8 // engine nozzles are good at radiating.
@@ -26,7 +26,7 @@ PART
 	breakingTorque = 200
 	maxTemp = 2000 // = 3600
 	bulkheadProfiles = size2
-	tags = orbit, direct, upper, vacuum, jupiter, ares, saturn
+	tags = orbit, direct, upper, vacuum, jupiter, ares, saturn, J2, J2X
 
 	MODEL
 	{


### PR DESCRIPTION
3.125m parts rebalance

-Ares I upper stage tanks fuel and masses rebalanced based on balance document provided by CobaltWolf.

Ares I can now comfortably make orbit. Tested in JNSQ (2.7x scale Kerbin). Into 90km orbit with 500 m/s spare with Mechjeb PVG guidance.

-ICPS balance also adjusted. Small adjustment to fuel, larger adjustment to dry mass.
ICPS and DCSS tags added.

-J2X mass reduced to 2T. (Same as Cryotanks J2X and more than BDB J2 which is 1.5T)
J2 tags added.